### PR TITLE
fix: expose socket utility to avoid circular dependency

### DIFF
--- a/server/controllers/messageController.js
+++ b/server/controllers/messageController.js
@@ -2,7 +2,7 @@
 const Message = require('../models/Message');
 const Chat = require('../models/chat');
 const User = require('../models/User');
-const { io } = require('../index');
+const { getIO } = require('../utils/socket');
 
 /**
  * Send a new message (with optional image upload)
@@ -64,6 +64,7 @@ exports.sendNewMessage = async (req, res) => {
     await newMessage.populate('sender', 'name email');
     
     // Emit Socket.IO event to all users in the chat room
+    const io = getIO();
     io.to(`chat_${chatId}`).emit('new_message', {
       chatId,
       message: newMessage
@@ -148,6 +149,7 @@ exports.markMessagesAsRead = async (req, res) => {
     );
     
     // Emit Socket.IO event for real-time read status
+    const io = getIO();
     io.to(`chat_${chatId}`).emit('messages_read', {
       chatId,
       messageIds,

--- a/server/index.js
+++ b/server/index.js
@@ -6,8 +6,8 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 const http = require('http');
 const morgan = require('morgan');
-const { Server } = require('socket.io');
 const jwt = require('jsonwebtoken');
+const { initSocket } = require('./utils/socket');
 
 // Import routes
 const authRoutes = require('./routes/authRoutes');
@@ -64,14 +64,8 @@ mongoose.connect(process.env.MONGO_URI)
 // Create HTTP server
 const server = http.createServer(app);
 
-// Initialize Socket.IO with CORS configuration
-const io = new Server(server, {
-  cors: {
-    origin: process.env.CLIENT_URL || "http://localhost:5173",
-    methods: ["GET", "POST"],
-    credentials: true
-  }
-});
+// Initialize Socket.IO
+const io = initSocket(server);
 
 // Socket.IO authentication middleware
 const authenticateSocket = (socket, next) => {

--- a/server/utils/socket.js
+++ b/server/utils/socket.js
@@ -1,0 +1,24 @@
+const { Server } = require('socket.io');
+
+let io;
+
+function initSocket(server) {
+  io = new Server(server, {
+    cors: {
+      origin: process.env.CLIENT_URL || 'http://localhost:5173',
+      methods: ['GET', 'POST'],
+      credentials: true
+    }
+  });
+  return io;
+}
+
+function getIO() {
+  if (!io) {
+    throw new Error('Socket.io not initialized');
+  }
+  return io;
+}
+
+module.exports = { initSocket, getIO };
+


### PR DESCRIPTION
## Summary
- extract socket.io setup into reusable util
- initialize socket server via new util
- fetch socket instance in message controller to broadcast events

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Missing script: "test")*
- `node test-socket.js`

------
https://chatgpt.com/codex/tasks/task_e_6892677ac5e4832bb68f63d02a95875e